### PR TITLE
0.57.0

### DIFF
--- a/.github/workflows/frpc-amd64.yml
+++ b/.github/workflows/frpc-amd64.yml
@@ -41,6 +41,6 @@ jobs:
           push: true
           tags: |
             snowdreamtechamd64/frpc:latest
-            snowdreamtechamd64/frpc:0.56.0
+            snowdreamtechamd64/frpc:0.57.0
             ghcr.io/snowdreamtech/frpc:amd64-latest
-            ghcr.io/snowdreamtech/frpc:amd64-0.56.0            
+            ghcr.io/snowdreamtech/frpc:amd64-0.57.0            

--- a/.github/workflows/frpc-arm32v6.yml
+++ b/.github/workflows/frpc-arm32v6.yml
@@ -41,6 +41,6 @@ jobs:
           push: true
           tags: |
             snowdreamtecharm32v6/frpc:latest
-            snowdreamtecharm32v6/frpc:0.56.0
+            snowdreamtecharm32v6/frpc:0.57.0
             ghcr.io/snowdreamtech/frpc:arm32v6-latest
-            ghcr.io/snowdreamtech/frpc:arm32v6-0.56.0        
+            ghcr.io/snowdreamtech/frpc:arm32v6-0.57.0        

--- a/.github/workflows/frpc-arm32v7.yml
+++ b/.github/workflows/frpc-arm32v7.yml
@@ -41,6 +41,6 @@ jobs:
           push: true
           tags: |
             snowdreamtecharm32v7/frpc:latest
-            snowdreamtecharm32v7/frpc:0.56.0
+            snowdreamtecharm32v7/frpc:0.57.0
             ghcr.io/snowdreamtech/frpc:arm32v7-latest
-            ghcr.io/snowdreamtech/frpc:arm32v7-0.56.0            
+            ghcr.io/snowdreamtech/frpc:arm32v7-0.57.0            

--- a/.github/workflows/frpc-arm64v8.yml
+++ b/.github/workflows/frpc-arm64v8.yml
@@ -41,6 +41,6 @@ jobs:
           push: true
           tags: |
             snowdreamtecharm64v8/frpc:latest
-            snowdreamtecharm64v8/frpc:0.56.0
+            snowdreamtecharm64v8/frpc:0.57.0
             ghcr.io/snowdreamtech/frpc:arm64v8-latest
-            ghcr.io/snowdreamtech/frpc:arm64v8-0.56.0            
+            ghcr.io/snowdreamtech/frpc:arm64v8-0.57.0            

--- a/.github/workflows/frps-amd64.yml
+++ b/.github/workflows/frps-amd64.yml
@@ -41,6 +41,6 @@ jobs:
           push: true
           tags: |
             snowdreamtechamd64/frps:latest
-            snowdreamtechamd64/frps:0.56.0
+            snowdreamtechamd64/frps:0.57.0
             ghcr.io/snowdreamtech/frps:amd64-latest
-            ghcr.io/snowdreamtech/frps:amd64-0.56.0            
+            ghcr.io/snowdreamtech/frps:amd64-0.57.0            

--- a/.github/workflows/frps-arm32v6.yml
+++ b/.github/workflows/frps-arm32v6.yml
@@ -41,6 +41,6 @@ jobs:
           push: true
           tags: |
             snowdreamtecharm32v6/frps:latest
-            snowdreamtecharm32v6/frps:0.56.0
+            snowdreamtecharm32v6/frps:0.57.0
             ghcr.io/snowdreamtech/frps:arm32v6-latest
-            ghcr.io/snowdreamtech/frps:arm32v6-0.56.0
+            ghcr.io/snowdreamtech/frps:arm32v6-0.57.0

--- a/.github/workflows/frps-arm32v7.yml
+++ b/.github/workflows/frps-arm32v7.yml
@@ -41,6 +41,6 @@ jobs:
           push: true
           tags: |
             snowdreamtecharm32v7/frps:latest
-            snowdreamtecharm32v7/frps:0.56.0
+            snowdreamtecharm32v7/frps:0.57.0
             ghcr.io/snowdreamtech/frps:arm32v7-latest
-            ghcr.io/snowdreamtech/frps:arm32v7-0.56.0            
+            ghcr.io/snowdreamtech/frps:arm32v7-0.57.0            

--- a/.github/workflows/frps-arm64v8.yml
+++ b/.github/workflows/frps-arm64v8.yml
@@ -41,6 +41,6 @@ jobs:
           push: true
           tags: |
             snowdreamtecharm64v8/frps:latest
-            snowdreamtecharm64v8/frps:0.56.0
+            snowdreamtecharm64v8/frps:0.57.0
             ghcr.io/snowdreamtech/frps:arm64v8-latest
-            ghcr.io/snowdreamtech/frps:arm64v8-0.56.0            
+            ghcr.io/snowdreamtech/frps:arm64v8-0.57.0            

--- a/frpc-dockerhub.yaml
+++ b/frpc-dockerhub.yaml
@@ -1,5 +1,5 @@
 image: snowdreamtech/frpc:latest
-tags: ["latest","0.56.0"]
+tags: ["latest","0.57.0"]
 manifests:
   - image: snowdreamtechamd64/frpc:latest
     platform:

--- a/frpc-github.yaml
+++ b/frpc-github.yaml
@@ -1,5 +1,5 @@
 image: ghcr.io/snowdreamtech/frpc:latest
-tags: ["latest","0.56.0"]
+tags: ["latest","0.57.0"]
 manifests:
   - image: ghcr.io/snowdreamtech/frpc:amd64-latest
     platform:

--- a/frpc/amd64/Dockerfile
+++ b/frpc/amd64/Dockerfile
@@ -2,7 +2,7 @@ FROM amd64/alpine:3.18
 
 LABEL maintainer="snowdream <sn0wdr1am@icloud.com>"
 
-ENV FRP_VERSION 0.56.0
+ENV FRP_VERSION 0.57.0
 
 RUN cd /root \
     &&  wget --no-check-certificate -c https://github.com/fatedier/frp/releases/download/v${FRP_VERSION}/frp_${FRP_VERSION}_linux_amd64.tar.gz \

--- a/frpc/arm32v6/Dockerfile
+++ b/frpc/arm32v6/Dockerfile
@@ -2,7 +2,7 @@ FROM arm32v6/alpine:3.18
 
 LABEL maintainer="snowdream <sn0wdr1am@icloud.com>"
 
-ENV FRP_VERSION 0.56.0
+ENV FRP_VERSION 0.57.0
 
 RUN cd /root \
     &&  wget --no-check-certificate -c https://github.com/fatedier/frp/releases/download/v${FRP_VERSION}/frp_${FRP_VERSION}_linux_arm.tar.gz \

--- a/frpc/arm32v7/Dockerfile
+++ b/frpc/arm32v7/Dockerfile
@@ -2,7 +2,7 @@ FROM arm32v7/alpine:3.18
 
 LABEL maintainer="snowdream <sn0wdr1am@icloud.com>"
 
-ENV FRP_VERSION 0.56.0
+ENV FRP_VERSION 0.57.0
 
 RUN cd /root \
     &&  wget --no-check-certificate -c https://github.com/fatedier/frp/releases/download/v${FRP_VERSION}/frp_${FRP_VERSION}_linux_arm.tar.gz \

--- a/frpc/arm64v8/Dockerfile
+++ b/frpc/arm64v8/Dockerfile
@@ -2,7 +2,7 @@ FROM arm64v8/alpine:3.18
 
 LABEL maintainer="snowdream <sn0wdr1am@icloud.com>"
 
-ENV FRP_VERSION 0.56.0
+ENV FRP_VERSION 0.57.0
 
 RUN cd /root \
     &&  wget --no-check-certificate -c https://github.com/fatedier/frp/releases/download/v${FRP_VERSION}/frp_${FRP_VERSION}_linux_arm64.tar.gz \

--- a/frps-dockerhub.yaml
+++ b/frps-dockerhub.yaml
@@ -1,5 +1,5 @@
 image: snowdreamtech/frps:latest
-tags: ["latest","0.56.0"]
+tags: ["latest","0.57.0"]
 manifests:
   - image: snowdreamtechamd64/frps:latest
     platform:

--- a/frps-github.yaml
+++ b/frps-github.yaml
@@ -1,5 +1,5 @@
 image: ghcr.io/snowdreamtech/frps:latest
-tags: ["latest","0.56.0"]
+tags: ["latest","0.57.0"]
 manifests:
   - image: ghcr.io/snowdreamtech/frps:amd64-latest
     platform:

--- a/frps/amd64/Dockerfile
+++ b/frps/amd64/Dockerfile
@@ -2,7 +2,7 @@ FROM amd64/alpine:3.18
 
 LABEL maintainer="snowdream <sn0wdr1am@icloud.com>"
 
-ENV FRP_VERSION 0.56.0
+ENV FRP_VERSION 0.57.0
 
 RUN cd /root \
     &&  wget --no-check-certificate -c https://github.com/fatedier/frp/releases/download/v${FRP_VERSION}/frp_${FRP_VERSION}_linux_amd64.tar.gz \

--- a/frps/arm32v6/Dockerfile
+++ b/frps/arm32v6/Dockerfile
@@ -2,7 +2,7 @@ FROM arm32v6/alpine:3.18
 
 LABEL maintainer="snowdream <sn0wdr1am@icloud.com>"
 
-ENV FRP_VERSION 0.56.0
+ENV FRP_VERSION 0.57.0
 
 RUN cd /root \
     &&  wget --no-check-certificate -c https://github.com/fatedier/frp/releases/download/v${FRP_VERSION}/frp_${FRP_VERSION}_linux_arm.tar.gz \

--- a/frps/arm32v7/Dockerfile
+++ b/frps/arm32v7/Dockerfile
@@ -2,7 +2,7 @@ FROM arm32v7/alpine:3.18
 
 LABEL maintainer="snowdream <sn0wdr1am@icloud.com>"
 
-ENV FRP_VERSION 0.56.0
+ENV FRP_VERSION 0.57.0
 
 RUN cd /root \
     &&  wget --no-check-certificate -c https://github.com/fatedier/frp/releases/download/v${FRP_VERSION}/frp_${FRP_VERSION}_linux_arm.tar.gz \

--- a/frps/arm64v8/Dockerfile
+++ b/frps/arm64v8/Dockerfile
@@ -2,7 +2,7 @@ FROM arm64v8/alpine:3.18
 
 LABEL maintainer="snowdream <sn0wdr1am@icloud.com>"
 
-ENV FRP_VERSION 0.56.0
+ENV FRP_VERSION 0.57.0
 
 RUN cd /root \
     &&  wget --no-check-certificate -c https://github.com/fatedier/frp/releases/download/v${FRP_VERSION}/frp_${FRP_VERSION}_linux_arm64.tar.gz \


### PR DESCRIPTION
Features
https2http and https2https plugin now supports X-Forwared-For header. Fixes
X-Forwared-For header is now correctly set in the request to the backend server for proxy type http.